### PR TITLE
kubernetes-operators hw

### DIFF
--- a/kubernetes-operators/deploy/cr.yml
+++ b/kubernetes-operators/deploy/cr.yml
@@ -1,0 +1,9 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: mysql-instance
+spec:
+  image: mysql:5.7
+  database: otus-database
+  password: otuspassword # Так делать не нужно, следует использовать secret
+  storage_size: 1Gi

--- a/kubernetes-operators/deploy/crd.yml
+++ b/kubernetes-operators/deploy/crd.yml
@@ -1,0 +1,43 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework # имя CRD должно иметь формат plural.group
+spec:
+  scope: Namespaced     # Данный CRD будер работать в рамках namespace
+  group: otus.homework  # Группа, отражается в поле apiVersion CR
+  versions:             # Список версий
+    - name: v1
+      served: true      # Будет ли обслуживаться API-сервером данная версия
+      storage: true     # Фиксирует  версию описания, которая будет сохраняться в etcd
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: ["spec"]
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+            spec:
+              type: object
+              required: ["image", "database", "password", "storage_size"]
+              properties:
+                image:
+                  type: string
+                database:
+                  type: string
+                password:
+                  type: string
+                storage_size:
+                  type: string
+  names:                # различные форматы имени объекта CR
+    kind: MySQL         # kind CR
+    plural: mysqls      
+    singular: mysql
+    shortNames:
+      - ms

--- a/kubernetes-operators/deploy/deploy-operator.yml
+++ b/kubernetes-operators/deploy/deploy-operator.yml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mysql-operator
+  template:
+    metadata:
+      labels:
+        name: mysql-operator
+    spec:
+      serviceAccountName: mysql-operator
+      containers:
+        - name: operator
+          image: "wenger23/mysql-operator:1.1"
+          imagePullPolicy: "Always"

--- a/kubernetes-operators/deploy/role-binding.yml
+++ b/kubernetes-operators/deploy/role-binding.yml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: workshop-operator
+subjects:
+- kind: ServiceAccount
+  name: mysql-operator
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mysql-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-operators/deploy/role.yml
+++ b/kubernetes-operators/deploy/role.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: mysql-operator
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/kubernetes-operators/deploy/service-account.yml
+++ b/kubernetes-operators/deploy/service-account.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator


### PR DESCRIPTION
# Выполнено ДЗ №7

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - С помощью minikube развернут кластер в составе сингл-ноды
```
smarin@otus:/root/otus/68sergey68_platform$ kubectl get node
NAME       STATUS   ROLES                  AGE   VERSION
minikube   Ready    control-plane,master   46d   v1.23.3
```
- применены манифесты cr и crd. crd не хотел создаваться в первоначальном виде:
```
smarin@otus:/root/otus/68sergey68_platform/kubernetes-operators/deploy$ kubectl apply -f crd.yml
The CustomResourceDefinition "mysqls.otus.homework" is invalid: spec.versions[0].schema.openAPIV3Schema: Required value: schemas are required
```
Поэтому сразу добавил блок schema

cr тоже ругается, исправил:
```
smarin@otus:/root/otus/68sergey68_platform/kubernetes-operators/deploy$ kubectl apply -f cr.yml
error: error validating "cr.yml": error validating data: ValidationError(MySQL): unknown field "usless_data" in homework.otus.v1.MySQL; if you choose to ignore these errors, turn validation off with --validate=false
```
- копипаст манифестов и применение их в кластер
- дожидемся...
```
smarin@otus:/root/otus/68sergey68_platform/kubernetes-operators/deploy$ kubectl get po -A
NAMESPACE     NAME                               READY   STATUS              RESTARTS       AGE
default       mysql-operator-b9f7f9b48-r75nb     0/1     ContainerCreating   0              4m23s
```
проверяем:
```
smarin@otus:/root/otus/68sergey68_platform/kubernetes-operators/deploy$ kubectl get pvc
NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
backup-mysql-instance-pvc   Bound    pvc-e5c6db7c-3791-467b-bb51-f0cf5f24e3a1   1Gi        RWO            standard       2m
mysql-instance-pvc          Bound    pvc-312cd33b-f37e-4fd3-a655-2dba09387764   1Gi        RWO            standard       2m
```
удалил, проверил джоб
```
smarin@otus:/root/otus/68sergey68_platform/kubernetes-operators/deploy$ kubectl get jobs.batch
NAME                        COMPLETIONS   DURATION   AGE
backup-mysql-instance-job   1/1           2s         28s
```
## Как запустить проект:
 - kubectl apply -f deploy/cr.yml 

## Как проверить работоспособность:
 - smarin@otus:/root/otus/68sergey68_platform/kubernetes-operators/deploy$ kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
mysql: [Warning] Using a password on the command line interface can be insecure.
+----+-------------+
| id | name        |
+----+-------------+
|  1 | some data   |
|  2 | some data-2 |
+----+-------------+

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
